### PR TITLE
Refactor/memo

### DIFF
--- a/src/main/java/com/example/pventure/domain/place/entity/Place.java
+++ b/src/main/java/com/example/pventure/domain/place/entity/Place.java
@@ -23,6 +23,9 @@ public class Place extends BaseEntity {
     @Column(length = 500)
     private String address;
 
+    @Column(length = 500)
+    private String memo;
+
     @Column
     @DecimalMax(value = "90.0")
     @DecimalMin(value = "-90.0")

--- a/src/main/java/com/example/pventure/domain/schedule/dto/request/ScheduleRequestDto.java
+++ b/src/main/java/com/example/pventure/domain/schedule/dto/request/ScheduleRequestDto.java
@@ -16,13 +16,11 @@ public class ScheduleRequestDto {
     private Integer day;
     private Integer sequence;
     private Boolean isCompleted;
-    private String memo;
 
     public Schedule toEntity(Trip trip,Integer finalSeq) {
         return Schedule.builder()
                 .day(day)
                 .sequence(finalSeq)
-                .memo(memo)
                 .isCompleted(isCompleted != null && isCompleted)
                 .trip(trip)
                 .build();

--- a/src/main/java/com/example/pventure/domain/schedule/dto/request/ScheduleUpdateDto.java
+++ b/src/main/java/com/example/pventure/domain/schedule/dto/request/ScheduleUpdateDto.java
@@ -12,6 +12,5 @@ import lombok.NoArgsConstructor;
 public class ScheduleUpdateDto {
 
     private Boolean isCompleted;
-    private String memo;
 
 }

--- a/src/main/java/com/example/pventure/domain/schedule/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/com/example/pventure/domain/schedule/dto/response/ScheduleResponseDto.java
@@ -21,7 +21,6 @@ public class ScheduleResponseDto {
     private Integer day;
     private Integer sequence;
     private LocalDate date;
-    private String memo;
 
     public static ScheduleResponseDto from(Schedule schedule) {
         LocalDate date = null;
@@ -38,7 +37,6 @@ public class ScheduleResponseDto {
                 .sequence(schedule.getSequence())
                 .isCompleted(schedule.isCompleted())
                 .date(date)
-                .memo(schedule.getMemo())
                 .build();
     }
 }

--- a/src/main/java/com/example/pventure/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/pventure/domain/schedule/entity/Schedule.java
@@ -26,9 +26,6 @@ public class Schedule extends BaseEntity {
     @Column(nullable = false)
     private Integer sequence;
 
-    @Column(length = 500)
-    private String memo;
-
     @Builder.Default
     @Column(nullable = false)
     private boolean isCompleted = false;
@@ -39,10 +36,6 @@ public class Schedule extends BaseEntity {
 
     public void updateSequence(Integer sequence) {
         this.sequence = sequence;
-    }
-
-    public void updateMemo(String memo) {
-        this.memo = memo;
     }
 
     public void updateCompleted(boolean isCompleted) {

--- a/src/main/java/com/example/pventure/domain/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/pventure/domain/schedule/service/ScheduleServiceImpl.java
@@ -131,7 +131,6 @@ public class ScheduleServiceImpl implements ScheduleService {
             throw new ApiException(ErrorCode.NOT_FOUND_SCHEDULE);
         }
 
-        if (dto.getMemo() != null) schedule.updateMemo(dto.getMemo());
         if (dto.getIsCompleted() != null) schedule.updateCompleted(dto.getIsCompleted());
 
         return ScheduleResponseDto.from(schedule);

--- a/src/main/resources/db/migration/dev/V1__insert_seed_data.sql
+++ b/src/main/resources/db/migration/dev/V1__insert_seed_data.sql
@@ -54,46 +54,46 @@ VALUES
 -- =====================================================
 -- 5. Schedule
 -- =====================================================
-INSERT INTO schedule (id, trip_id, day, sequence, memo, is_completed, created_at, updated_at)
+INSERT INTO schedule (id, trip_id, day, sequence, is_completed, created_at, updated_at)
 VALUES
     -- 서울 여행
-    (1, 1, 1, 1, '경복궁 방문', FALSE, NOW(), NOW()),
-    (2, 1, 2, 1, '남산타워 전망대', FALSE, NOW(), NOW()),
+    (1, 1, 1, 1, FALSE, NOW(), NOW()),
+    (2, 1, 2, 1, FALSE, NOW(), NOW()),
     -- 부산 여행
-    (3, 2, 1, 1, '해운대 산책', FALSE, NOW(), NOW()),
-    (4, 2, 2, 1, '광안리 야경', FALSE, NOW(), NOW()),
+    (3, 2, 1, 1, FALSE, NOW(), NOW()),
+    (4, 2, 2, 1, FALSE, NOW(), NOW()),
     -- 제주 여행
-    (5, 3, 1, 1, '한라산 등반', FALSE, NOW(), NOW()),
-    (6, 3, 2, 1, '성산일출봉 방문', FALSE, NOW(), NOW()),
-    (7, 3, 3, 1, '협재 해수욕장', FALSE, NOW(), NOW()),
+    (5, 3, 1, 1, FALSE, NOW(), NOW()),
+    (6, 3, 2, 1, FALSE, NOW(), NOW()),
+    (7, 3, 3, 1, FALSE, NOW(), NOW()),
     -- 강릉 여행
-    (8, 4, 1, 1, '정동진 일출', FALSE, NOW(), NOW()),
-    (9, 4, 2, 1, '경포대 산책', FALSE, NOW(), NOW()),
+    (8, 4, 1, 1, FALSE, NOW(), NOW()),
+    (9, 4, 2, 1, FALSE, NOW(), NOW()),
     -- 여수 여행
-    (10, 5, 1, 1, '오동도 관광', FALSE, NOW(), NOW()),
-    (11, 5, 2, 1, '돌산대교 야경', FALSE, NOW(), NOW());
+    (10, 5, 1, 1, FALSE, NOW(), NOW()),
+    (11, 5, 2, 1, FALSE, NOW(), NOW());
 
 -- =====================================================
 -- 6. Place
 -- =====================================================
-INSERT INTO place (id, name, link, address, latitude, longitude, place_category, schedule_id, created_at, updated_at)
+INSERT INTO place (id, name, link, address, latitude, longitude, place_category, schedule_id, memo, created_at, updated_at)
 VALUES
     -- 서울 여행
-    (1, '경복궁', 'https://gyeongbokgung.or.kr', '서울 종로구 사직로 161', 37.579617, 126.977041, 'TOURIST_ATTRACTION', 1, NOW(), NOW()),
-    (2, '남산타워', 'https://nseoultower.co.kr', '서울 용산구 남산공원길 105', 37.551169, 126.988227, 'TOURIST_ATTRACTION', 2, NOW(), NOW()),
+    (1, '경복궁', 'https://gyeongbokgung.or.kr', '서울 종로구 사직로 161', 37.579617, 126.977041, 'TOURIST_ATTRACTION', 1, '경복궁 방문', NOW(), NOW()),
+    (2, '남산타워', 'https://nseoultower.co.kr', '서울 용산구 남산공원길 105', 37.551169, 126.988227, 'TOURIST_ATTRACTION', 2, '남산타워 전망대', NOW(), NOW()),
     -- 부산 여행
-    (3, '해운대', 'https://www.haeundae.go.kr', '부산 해운대구', 35.1587, 129.1604, 'TOURIST_ATTRACTION', 3, NOW(), NOW()),
-    (4, '광안리', 'https://www.gwangalli.go.kr', '부산 수영구', 35.1535, 129.1187, 'TOURIST_ATTRACTION', 4, NOW(), NOW()),
+    (3, '해운대', 'https://www.haeundae.go.kr', '부산 해운대구', 35.1587, 129.1604, 'TOURIST_ATTRACTION', 3, '해운대 산책', NOW(), NOW()),
+    (4, '광안리', 'https://www.gwangalli.go.kr', '부산 수영구', 35.1535, 129.1187, 'TOURIST_ATTRACTION', 4, '광안리 야경', NOW(), NOW()),
     -- 제주 여행
-    (5, '한라산', 'https://www.hallasan.go.kr', '제주 한라산', 33.3617, 126.5292, 'TOURIST_ATTRACTION', 5, NOW(), NOW()),
-    (6, '성산일출봉', 'https://www.jeju.go.kr', '제주 성산', 33.4581, 126.9410, 'TOURIST_ATTRACTION', 6, NOW(), NOW()),
-    (7, '협재 해수욕장', 'https://www.jeju.go.kr', '제주 협재', 33.2479, 126.2395, 'TOURIST_ATTRACTION', 7, NOW(), NOW()),
+    (5, '한라산', 'https://www.hallasan.go.kr', '제주 한라산', 33.3617, 126.5292, 'TOURIST_ATTRACTION', 5, '한라산 등반', NOW(), NOW()),
+    (6, '성산일출봉', 'https://www.jeju.go.kr', '제주 성산', 33.4581, 126.9410, 'TOURIST_ATTRACTION', 6, '성산일출봉 방문', NOW(), NOW()),
+    (7, '협재 해수욕장', 'https://www.jeju.go.kr', '제주 협재', 33.2479, 126.2395, 'TOURIST_ATTRACTION', 7, '협재 해수욕장', NOW(), NOW()),
     -- 강릉 여행
-    (8, '정동진', 'https://www.jeongdongjin.go.kr', '강릉 정동진', 37.7566, 129.1133, 'TOURIST_ATTRACTION', 8, NOW(), NOW()),
-    (9, '경포대', 'https://www.gangneung.go.kr', '강릉 경포', 37.7519, 128.8955, 'TOURIST_ATTRACTION', 9, NOW(), NOW()),
+    (8, '정동진', 'https://www.jeongdongjin.go.kr', '강릉 정동진', 37.7566, 129.1133, 'TOURIST_ATTRACTION', 8, '정동진 일출', NOW(), NOW()),
+    (9, '경포대', 'https://www.gangneung.go.kr', '강릉 경포', 37.7519, 128.8955, 'TOURIST_ATTRACTION', 9, '경포대 산책', NOW(), NOW()),
     -- 여수 여행
-    (10, '오동도', 'https://www.yeosu.go.kr', '여수 오동도', 34.7405, 127.7212, 'TOURIST_ATTRACTION', 10, NOW(), NOW()),
-    (11, '돌산대교', 'https://www.yeosu.go.kr', '여수 돌산대교', 34.7291, 127.7576, 'TOURIST_ATTRACTION', 11, NOW(), NOW());
+    (10, '오동도', 'https://www.yeosu.go.kr', '여수 오동도', 34.7405, 127.7212, 'TOURIST_ATTRACTION', 10, '오동도 관광', NOW(), NOW()),
+    (11, '돌산대교', 'https://www.yeosu.go.kr', '여수 돌산대교', 34.7291, 127.7576, 'TOURIST_ATTRACTION', 11, '돌산대교 야경', NOW(), NOW());
 
 -- =====================================================
 -- 7. Album

--- a/src/test/java/com/example/pventure/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/example/pventure/domain/schedule/service/ScheduleServiceTest.java
@@ -69,7 +69,6 @@ class ScheduleServiceTest {
                 .trip(trip)
                 .day(1)
                 .sequence(1)
-                .memo("메모")
                 .build();
         setId(schedule, 1L);
 
@@ -90,14 +89,13 @@ class ScheduleServiceTest {
         when(scheduleRepository.save(any(Schedule.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(memberService.canEdit(user, trip)).thenReturn(true);
 
-        ScheduleRequestDto dto = new ScheduleRequestDto(1, 1, false, "메모");
+        ScheduleRequestDto dto = new ScheduleRequestDto(1, 1, false);
         ScheduleResponseDto response = scheduleService.createSchedule(trip.getId(), user.getId(), dto);
 
         verify(sequenceUtil).shiftOnInsert(trip.getId(), 1, 1);
         verify(scheduleRepository).save(any(Schedule.class));
         assertEquals(1, response.getDay());
         assertEquals(1, response.getSequence());
-        assertEquals("메모", response.getMemo());
     }
 
     @Test
@@ -109,7 +107,6 @@ class ScheduleServiceTest {
 
         List<ScheduleResponseDto> response = scheduleService.getSchedules(trip.getId(), user.getId(), 1);
         assertEquals(1, response.size());
-        assertEquals("메모", response.get(0).getMemo());
     }
 
     @Test
@@ -119,10 +116,8 @@ class ScheduleServiceTest {
         when(scheduleRepository.findById(schedule.getId())).thenReturn(Optional.of(schedule));
         when(memberService.canEdit(user, trip)).thenReturn(true);
 
-        ScheduleUpdateDto dto = new ScheduleUpdateDto(true, "new memo");
+        ScheduleUpdateDto dto = new ScheduleUpdateDto(true);
         ScheduleResponseDto response = scheduleService.updateSchedule(trip.getId(), schedule.getId(), user.getId(), dto);
-
-        assertEquals("new memo", response.getMemo());
         assertTrue(response.isCompleted());
     }
 
@@ -161,7 +156,7 @@ class ScheduleServiceTest {
     void createSchedule_fail_userNotFound() {
         when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        ScheduleRequestDto dto = new ScheduleRequestDto(1, 1, false, "메모");
+        ScheduleRequestDto dto = new ScheduleRequestDto(1, 1, false);
 
         ApiException ex = assertThrows(ApiException.class,
                 () -> scheduleService.createSchedule(trip.getId(), 999L, dto));
@@ -185,7 +180,7 @@ class ScheduleServiceTest {
         when(scheduleRepository.findById(999L)).thenReturn(Optional.empty());
         when(memberService.canEdit(user, trip)).thenReturn(true);
 
-        ScheduleUpdateDto dto = new ScheduleUpdateDto(true, "memo");
+        ScheduleUpdateDto dto = new ScheduleUpdateDto(true);
         ApiException ex = assertThrows(ApiException.class,
                 () -> scheduleService.updateSchedule(trip.getId(), 999L, user.getId(), dto));
         assertEquals(ErrorCode.NOT_FOUND_SCHEDULE, ex.getErrorCode());


### PR DESCRIPTION
## 📝 PR 요약 (Summary)
- `Schedule` 테이블에서 `memo` 필드 제거  
- `Place` 테이블에 `memo` 필드 추가  
- 관련 DTO, Entity, SQL Seed, 테스트 코드 수정 반영  

---

## 🔗 관련 이슈 (Related Issues)
Closes #32 

---

## 🧩 변경 유형 (Change Type)
- [x] 🚀 기능 추가 (Feature)
- [x] 🧰 코드 리팩토링 (Refactor)
- [x] 🧪 테스트 코드 추가 / 수정 (Test)

---

## 🧾 주요 변경 내용 (What was changed)
- `schedule` 테이블에서 `memo` 컬럼 제거  
- `place` 테이블에 `memo` 컬럼 추가  
- `Schedule`, `Place` 엔티티 및 DTO 수정  
- 테스트 코드 내 `memo` 필드 관련 검증 제거  
- SQL Seed 및 TestData 파일 수정  

---

## 🧪 테스트 및 검증 (Test)
- [x] 로컬 환경에서 정상 작동 확인  
- [x] 주요 시나리오 수동 검증 완료  
- [x] 테스트 코드 수정 및 통과  

결과 요약:  
> - DB 마이그레이션 이후 정상 실행 확인  
> - Place에 memo 입력 및 조회 정상 동작  

---

## ✅ PR 체크리스트 (Checklist)
- [x] 커밋 메시지와 PR 제목이 명확함  
- [x] 불필요한 주석 / 로그 제거  
- [x] 코드 포맷팅 완료  
- [x] 테스트 통과 확인  
- [x] 컨벤션 준수  

---

## 💬 추가 참고사항 (Notes)
- 추후 `Place` 관련 상세 조회 API에서도 `memo` 노출 여부 검토 예정  
- 관련 커밋:
  - `[FEAT] Sql 에서 Schedule memo 필드 제거 및 Place memo 필드 추가`
  - `[FEAT] TestCode 에서 Memo 필드 제거`
  - `[FEAT] schedule memo 필드 제거 및 place memo 필드 추가`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 방문 장소에 메모를 추가할 수 있습니다. (최대 500자)

* **변경 사항**
  * 메모 기능이 일정에서 장소로 이동되었습니다. 각 방문 장소마다 개별 메모를 작성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->